### PR TITLE
Basic plugin management tool

### DIFF
--- a/app/Console/Commands/NoteFormat.php
+++ b/app/Console/Commands/NoteFormat.php
@@ -101,11 +101,11 @@ class NoteFormatter
             return;
         }
 
-         $this->state->installed = collect($this->state->installed)->forget($index-1);
+        $this->state->installed = array_values(collect($this->state->installed)->forget($index-1)->toArray());
 
-         $this->writeToOutput();
+        $this->writeToOutput();
 
-         File::put($this::STATE, json_encode($this->state));
+        File::put($this::STATE, json_encode($this->state));
    }
 
     

--- a/app/Console/Commands/NoteFormat.php
+++ b/app/Console/Commands/NoteFormat.php
@@ -19,6 +19,7 @@ class NoteFormatter
     const STATE = "./resources/note-format/state.json";
     const REPOSITORY = "./resources/note-format/repository.json";
     const OUT  = "./resources/note-format/note-format.out.js";
+    const COMMON_JS = "./resources/note-format/src/common.js";
 
 
     public function getRepository() {
@@ -38,7 +39,7 @@ class NoteFormatter
     }
 
     public function writeToOutput() {
-        $out = "const formatters=[";
+        $out = File::get(NoteFormatter::COMMON_JS)."\nconst formatters=[";
         foreach ($this->state->installed as $installed) {
             $out .= sprintf("%s,", File::get($this::DIR.$this->repo[$installed]->src));
         }

--- a/app/Console/Commands/NoteFormat.php
+++ b/app/Console/Commands/NoteFormat.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+class NoteFormatter extends Command
+{
+    private $map;
+
+    public function __construct() {
+        $this->map = $this->getMap();
+    }
+
+    const DIR = "./resources/note-format/";
+    const REPOSITORY = "./resources/note-format/repository.json";
+    const OUT  = "./resources/note-format/note-format.out.js";
+
+
+    public function getContent() {
+        return json_decode(File::get(NoteFormatter::REPOSITORY));
+    }
+
+
+    public function getMap() {
+        return collect(NoteFormatter::getContent())->reduce(function($map, $plugin) {
+            $map[$plugin->name] = $plugin;
+            return $map;
+        });
+    }
+
+    public function getInstalled() {
+        return collect(array_keys($this->map))->filter(function($name) {
+            return $this->map[$name]->installed;
+        });
+    }
+
+    public function writeToOutput() {
+        $out = "const formatters = {\n";
+        foreach ($this->getInstalled() as $installed) {
+            $out .= sprintf("%s: %s,\n",
+                $installed, File::get($this::DIR.$this->map[$installed]->src));
+        }
+        $out .= "}";
+
+        File::put($this::OUT, $out);
+    }
+
+
+    public function list() {
+        $plugins = json_decode(File::get($this::REPOSITORY), true);
+        printf("%d available formatters\n\n", count(array_keys($plugins)));
+        foreach ($plugins as $name=>$plugin) {
+            printf("%s%-20s - %s\n",
+                $plugin["installed"] ? "* " : "  ", $name, $plugin["description"]);
+        }
+    }
+
+
+    public function install($requested) {
+        foreach ($requested as $plugin) {
+            if (!isset($this->map[$plugin])) {
+                printf("[ERROR] Formatter $plugin does not exist\n");
+                return;
+            }
+        }
+
+        foreach ($requested as $plugin) {
+            $this->map[$plugin]->installed = true;
+        }
+
+        $this->writeToOutput();
+
+        File::put($this::REPOSITORY, json_encode($this->map, JSON_PRETTY_PRINT));
+    }
+
+
+    public function remove($requested) {
+         foreach ($requested as $plugin) {
+            if (!isset($this->map[$plugin])) {
+                printf("[ERROR] Formatter $plugin does not exist\n");
+                return;
+            }
+        }
+
+        foreach ($requested as $plugin) {
+            $this->map[$plugin]->installed = false;
+        }
+
+        $this->writeToOutput();
+
+        File::put($this::REPOSITORY, json_encode($this->map, JSON_PRETTY_PRINT));
+   }
+
+    
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -252,7 +252,7 @@ a {
     .right .preview-view h1 {
       width: 100%;
       margin-bottom: 30px;
-      font-size: 1em; }
+      font-size: 2em; }
       .right .preview-view h1 span {
         width: 70%;
         display: block;
@@ -264,9 +264,14 @@ a {
         padding-bottom: 15px;
         color: #333333; }
     .right .preview-view .preview-area {
-      padding: 10px 40px; }
+      padding: 10px 40px;
+      width: 100%; }
       .right .preview-view .preview-area pre {
         word-wrap: break-word;
         white-space: pre-wrap; }
+      .right .preview-view .preview-area iframe.javascript {
+        width: 100%;
+        border: 1px solid #DDD;
+        resize: vertical; }
 
 /*# sourceMappingURL=style.css.map */

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,3 +1,10 @@
+const formatters=[function(note) {
+    note.html = 'this is markdown';
+
+    return note;
+}
+,]
+
 const emptyNote = {
     id: 0,
     title: '',
@@ -34,14 +41,19 @@ const SelectedNote = {
         DESELECT_NOTE: state =>
             state.selectedNote = emptyNote,
 
-        RENDER_SELECTED_NOTE: state =>
-            state.selectedNote.html = new showdown.Converter()
-                .makeHtml(state.selectedNote.body)
-                .replace(/\$asciinema\([^\)\(]+\)/g, match => {
-                    var filename = match.substring(11).slice(0, -1);
-                    var path = ['./attachments', store.getters.getSelection.id, filename].join('/');
-                    return `<asciinema-player src="${path}"></asciinema-player>`;
-                }),
+        RENDER_SELECTED_NOTE: state => {
+            state.selectedNote.html = state.selectedNote.body;
+            state.selectedNote = formatters.reduce(function(note, formatter) {
+                return formatter(note);
+            }, state.selectedNote);
+            // state.selectedNote.html = new showdown.Converter()
+            //     .makeHtml(state.selectedNote.body)
+            //     .replace(/\$asciinema\([^\)\(]+\)/g, match => {
+            //         var filename = match.substring(11).slice(0, -1);
+            //         var path = ['./attachments', store.getters.getSelection.id, filename].join('/');
+            //         return `<asciinema-player src="${path}"></asciinema-player>`;
+            //     }),
+        },
 
         REMOVE_ATTACHMENT: (state, index) =>
             Vue.delete(this.selectedNote.attachments, index),
@@ -415,6 +427,8 @@ const Attachments = {
 }
 
 
+
+//
 
 
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -53,55 +53,12 @@ const formatters=[function (body) {
         return new showdown.Converter().makeHtml(body);
     });
 }
-,function (body, note) {
-    return loadScript('asciinema', 'js/asciinema-player.js')
-    .then(() => {
-        return body.replace(/\$asciinema\([^\)\(]+\)/g, match => {
-           var filename = match.substring(11).slice(0, -1);
-           var path = ['./attachments', note.id, filename].join('/');
-           return `<asciinema-player src="${path}"></asciinema-player>`;
-       })
-    });
-}
-,function (body) {
-    return loadScript('mathjax',
-        'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?' +
-        'config=TeX-MML-AM_CHTML')
-    .then(() => {
-        Vue.nextTick(_ => MathJax.Hub.Queue(["Typeset", MathJax.Hub]));
-        return body;
-    });
-}
 ,function (body) {
     var sandbox = document.createElement('div');
     sandbox.innerHTML = body;
 
     Array.from(sandbox.querySelectorAll('iframe')).forEach(iframe => {
         iframe.sandbox = 'allow-scripts allow-same-origin allow-forms';
-    });
-
-    return Promise.resolve(sandbox.innerHTML);
-}
-,function (body, note) {
-    const sandbox = document.createElement('div');
-    sandbox.innerHTML = body;
-
-    Array.from(sandbox.querySelectorAll('code.js')).forEach(elm => {
-        const escaper = document.createElement('textarea');
-        escaper.innerHTML = elm.innerHTML;
-
-        if (escaper.value.split('\n')[0].trim() !== '!eval') {
-            return;
-        }
-
-        const iframe = document.createElement('iframe');
-        iframe.sandbox = 'allow-scripts';
-        iframe.className = 'javascript';
-        iframe.srcdoc = '<script>'
-            + escaper.value.substring(6)
-            + '</script>';
-
-        elm.parentNode.replaceChild(iframe, elm);
     });
 
     return Promise.resolve(sandbox.innerHTML);

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -82,6 +82,28 @@ const formatters=[function (body) {
 
     return Promise.resolve(sandbox.innerHTML);
 }
+,function (body, note) {
+    const sandbox = document.createElement('div');
+    sandbox.innerHTML = body;
+
+    Array.from(sandbox.querySelectorAll('code.js')).forEach(elm => {
+        const escaper = document.createElement('textarea');
+        escaper.innerHTML = elm.innerHTML;
+
+        if (escaper.value.split('\n')[0].trim() !== '!eval') {
+            return;
+        }
+
+        const iframe = document.createElement('iframe');
+        iframe.sandbox = 'allow-scripts';
+        iframe.className = 'javascript';
+        iframe.srcdoc = '<script>' + escaper.value + '</script>';
+
+        elm.parentNode.replaceChild(iframe, elm);
+    });
+
+    return Promise.resolve(sandbox.innerHTML);
+}
 ,]
 
 function makeEmptyNote() {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -97,7 +97,9 @@ const formatters=[function (body) {
         const iframe = document.createElement('iframe');
         iframe.sandbox = 'allow-scripts';
         iframe.className = 'javascript';
-        iframe.srcdoc = '<script>' + escaper.value + '</script>';
+        iframe.srcdoc = '<script>'
+            + escaper.value.substring(6)
+            + '</script>';
 
         elm.parentNode.replaceChild(iframe, elm);
     });

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -15,10 +15,13 @@ function setConfig(key, val) {
 }
 
 function loadScript(name, src) {
+    console.log('NoteFormat requesting', name, src);
+
     const isLoaded = getConfig(name+'.loaded', false);
 
     return new Promise((resolve, reject) => {
         if (isLoaded) {
+            console.log('NoteFormat script already loaded', name);
             if (typeof resolve === 'function') {
                 resolve();
                 return;
@@ -30,6 +33,7 @@ function loadScript(name, src) {
         script.src = src;
 
         script.onload = _ => {
+            console.log('NoteFormat loaded', name);
             window.SHOWDOWN_LOADED = true;
             setConfig(name+'.loaded', true);
             if (typeof resolve === 'function') {
@@ -48,6 +52,35 @@ const formatters=[function (body) {
     .then(() => {
         return new showdown.Converter().makeHtml(body);
     });
+}
+,function (body, note) {
+    return loadScript('asciinema', 'js/asciinema-player.js')
+    .then(() => {
+        return body.replace(/\$asciinema\([^\)\(]+\)/g, match => {
+           var filename = match.substring(11).slice(0, -1);
+           var path = ['./attachments', note.id, filename].join('/');
+           return `<asciinema-player src="${path}"></asciinema-player>`;
+       })
+    });
+}
+,function (body) {
+    return loadScript('mathjax',
+        'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?' +
+        'config=TeX-MML-AM_CHTML')
+    .then(() => {
+        Vue.nextTick(_ => MathJax.Hub.Queue(["Typeset", MathJax.Hub]));
+        return body;
+    });
+}
+,function (body) {
+    var sandbox = document.createElement('div');
+    sandbox.innerHTML = body;
+
+    Array.from(sandbox.querySelectorAll('iframe')).forEach(iframe => {
+        iframe.sandbox = 'allow-scripts allow-same-origin allow-forms';
+    });
+
+    return Promise.resolve(sandbox.innerHTML);
 }
 ,]
 
@@ -102,13 +135,6 @@ const SelectedNote = {
             .then(html => {
                 Vue.set(state.selectedNote, 'html', html);
             });
-            // state.selectedNote.html = new showdown.Converter()
-            //     .makeHtml(state.selectedNote.body)
-            //     .replace(/\$asciinema\([^\)\(]+\)/g, match => {
-            //         var filename = match.substring(11).slice(0, -1);
-            //         var path = ['./attachments', store.getters.getSelection.id, filename].join('/');
-            //         return `<asciinema-player src="${path}"></asciinema-player>`;
-            //     }),
         },
 
         REMOVE_ATTACHMENT: (state, index) =>
@@ -193,7 +219,6 @@ const SelectedNote = {
             state.editing = false;
             state.versioning = false;
             commit('RENDER_SELECTED_NOTE');
-            dispatch('RENDER_MATHJAX');
         }
     }
 
@@ -541,10 +566,6 @@ SELECT_FIRST_NOTE: ({ state, commit, dispatch }) =>
     state.notes.length > 0 ?
         dispatch('SELECT_NOTE', state.notes[0]) :
         commit('DESELECT_NOTE'),
-
-
-RENDER_MATHJAX: ctx =>
-    Vue.nextTick(_ => MathJax.Hub.Queue(["Typeset", MathJax.Hub])),
 
 
 CREATE_NOTE: ({ state, commit, dispatch }) =>

--- a/public/sass/style.sass
+++ b/public/sass/style.sass
@@ -268,7 +268,7 @@ a
         h1
             width: 100%
             margin-bottom: 30px
-            font-size: 1em
+            font-size: 2em
             span
                 width: 70%
                 display: block
@@ -281,6 +281,11 @@ a
                 color: #333333
         .preview-area
             padding: 10px 40px
+            width: 100%
             pre
                 word-wrap: break-word
                 white-space: pre-wrap
+            iframe.javascript
+                width: 100%
+                border: 1px solid #DDD
+                resize: vertical

--- a/resources/note-format/note-format.out.js
+++ b/resources/note-format/note-format.out.js
@@ -82,4 +82,26 @@ const formatters=[function (body) {
 
     return Promise.resolve(sandbox.innerHTML);
 }
+,function (body, note) {
+    const sandbox = document.createElement('div');
+    sandbox.innerHTML = body;
+
+    Array.from(sandbox.querySelectorAll('code.js')).forEach(elm => {
+        const escaper = document.createElement('textarea');
+        escaper.innerHTML = elm.innerHTML;
+
+        if (escaper.value.split('\n')[0].trim() !== '!eval') {
+            return;
+        }
+
+        const iframe = document.createElement('iframe');
+        iframe.sandbox = 'allow-scripts';
+        iframe.className = 'javascript';
+        iframe.srcdoc = '<script>' + escaper.value + '</script>';
+
+        elm.parentNode.replaceChild(iframe, elm);
+    });
+
+    return Promise.resolve(sandbox.innerHTML);
+}
 ,]

--- a/resources/note-format/note-format.out.js
+++ b/resources/note-format/note-format.out.js
@@ -53,55 +53,12 @@ const formatters=[function (body) {
         return new showdown.Converter().makeHtml(body);
     });
 }
-,function (body, note) {
-    return loadScript('asciinema', 'js/asciinema-player.js')
-    .then(() => {
-        return body.replace(/\$asciinema\([^\)\(]+\)/g, match => {
-           var filename = match.substring(11).slice(0, -1);
-           var path = ['./attachments', note.id, filename].join('/');
-           return `<asciinema-player src="${path}"></asciinema-player>`;
-       })
-    });
-}
-,function (body) {
-    return loadScript('mathjax',
-        'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?' +
-        'config=TeX-MML-AM_CHTML')
-    .then(() => {
-        Vue.nextTick(_ => MathJax.Hub.Queue(["Typeset", MathJax.Hub]));
-        return body;
-    });
-}
 ,function (body) {
     var sandbox = document.createElement('div');
     sandbox.innerHTML = body;
 
     Array.from(sandbox.querySelectorAll('iframe')).forEach(iframe => {
         iframe.sandbox = 'allow-scripts allow-same-origin allow-forms';
-    });
-
-    return Promise.resolve(sandbox.innerHTML);
-}
-,function (body, note) {
-    const sandbox = document.createElement('div');
-    sandbox.innerHTML = body;
-
-    Array.from(sandbox.querySelectorAll('code.js')).forEach(elm => {
-        const escaper = document.createElement('textarea');
-        escaper.innerHTML = elm.innerHTML;
-
-        if (escaper.value.split('\n')[0].trim() !== '!eval') {
-            return;
-        }
-
-        const iframe = document.createElement('iframe');
-        iframe.sandbox = 'allow-scripts';
-        iframe.className = 'javascript';
-        iframe.srcdoc = '<script>'
-            + escaper.value.substring(6)
-            + '</script>';
-
-        elm.parentNode.replaceChild(iframe, elm);
     });
 
     return Promise.resolve(sandbox.innerHTML);

--- a/resources/note-format/note-format.out.js
+++ b/resources/note-format/note-format.out.js
@@ -1,0 +1,10 @@
+const formatters = {
+markdown: function(note) { return "markdown"; }
+,
+iframe: function(note) { return "iframe"; }
+,
+mathjax: function(note) { return "mathjax"; }
+,
+asciinema: function(note) { return "asciinema"; }
+,
+}

--- a/resources/note-format/note-format.out.js
+++ b/resources/note-format/note-format.out.js
@@ -97,7 +97,9 @@ const formatters=[function (body) {
         const iframe = document.createElement('iframe');
         iframe.sandbox = 'allow-scripts';
         iframe.className = 'javascript';
-        iframe.srcdoc = '<script>' + escaper.value + '</script>';
+        iframe.srcdoc = '<script>'
+            + escaper.value.substring(6)
+            + '</script>';
 
         elm.parentNode.replaceChild(iframe, elm);
     });

--- a/resources/note-format/note-format.out.js
+++ b/resources/note-format/note-format.out.js
@@ -1,10 +1,6 @@
-const formatters = {
-markdown: function(note) { return "markdown"; }
-,
-iframe: function(note) { return "iframe"; }
-,
-mathjax: function(note) { return "mathjax"; }
-,
-asciinema: function(note) { return "asciinema"; }
-,
+const formatters=[function(note) {
+    note.html = 'this is markdown';
+
+    return note;
 }
+,]

--- a/resources/note-format/repository.json
+++ b/resources/note-format/repository.json
@@ -1,0 +1,35 @@
+{
+    "markdown": {
+        "name": "markdown",
+        "description": "Renders the note in markdown",
+        "src": "src\/markdown.js",
+        "installed": true
+    },
+    "iframe": {
+        "name": "iframe",
+        "description": "Play around with iframe attributes or block them",
+        "src": "src\/iframe.js",
+        "args": {
+            "sandbox": [
+                "allow-scripts"
+            ]
+        },
+        "installed": true
+    },
+    "mathjax": {
+        "name": "mathjax",
+        "description": "Render LaTeX equations inside the note",
+        "src": "src\/mathjax.js",
+        "args": [],
+        "installed": true
+    },
+    "asciinema": {
+        "name": "asciinema",
+        "description": "Use $asciinema(attachment_url) to include an asciinema cast",
+        "src": "src\/asciinema.js",
+        "args": {
+            "function_name": "$asciinema"
+        },
+        "installed": true
+    }
+}

--- a/resources/note-format/repository.json
+++ b/resources/note-format/repository.json
@@ -18,5 +18,10 @@
         "name": "asciinema",
         "description": "Use $asciinema(attachment_url) to include an asciinema cast",
         "src": "src\/asciinema.js"
+    },
+    "js-eval": {
+        "name": "js-eval",
+        "description": "Evaluate javascript code and display output in an <iframe>",
+        "src": "src\/js-eval.js"
     }
 }

--- a/resources/note-format/repository.json
+++ b/resources/note-format/repository.json
@@ -2,34 +2,21 @@
     "markdown": {
         "name": "markdown",
         "description": "Renders the note in markdown",
-        "src": "src\/markdown.js",
-        "installed": true
+        "src": "src\/markdown.js"
     },
     "iframe": {
         "name": "iframe",
         "description": "Play around with iframe attributes or block them",
-        "src": "src\/iframe.js",
-        "args": {
-            "sandbox": [
-                "allow-scripts"
-            ]
-        },
-        "installed": true
+        "src": "src\/iframe.js"
     },
     "mathjax": {
         "name": "mathjax",
         "description": "Render LaTeX equations inside the note",
-        "src": "src\/mathjax.js",
-        "args": [],
-        "installed": true
+        "src": "src\/mathjax.js"
     },
     "asciinema": {
         "name": "asciinema",
         "description": "Use $asciinema(attachment_url) to include an asciinema cast",
-        "src": "src\/asciinema.js",
-        "args": {
-            "function_name": "$asciinema"
-        },
-        "installed": true
+        "src": "src\/asciinema.js"
     }
 }

--- a/resources/note-format/src/asciinema.js
+++ b/resources/note-format/src/asciinema.js
@@ -1,0 +1,1 @@
+function(note) { return "asciinema"; }

--- a/resources/note-format/src/asciinema.js
+++ b/resources/note-format/src/asciinema.js
@@ -1,1 +1,10 @@
-function(note) { return "asciinema"; }
+function (body, note) {
+    return loadScript('asciinema', 'js/asciinema-player.js')
+    .then(() => {
+        return body.replace(/\$asciinema\([^\)\(]+\)/g, match => {
+           var filename = match.substring(11).slice(0, -1);
+           var path = ['./attachments', note.id, filename].join('/');
+           return `<asciinema-player src="${path}"></asciinema-player>`;
+       })
+    });
+}

--- a/resources/note-format/src/common.js
+++ b/resources/note-format/src/common.js
@@ -42,11 +42,3 @@ function loadScript(name, src) {
 }
 
 
-
-const formatters=[function (body) {
-    return loadScript('showdown', 'js/showdown.min.js')
-    .then(() => {
-        return new showdown.Converter().makeHtml(body);
-    });
-}
-,]

--- a/resources/note-format/src/common.js
+++ b/resources/note-format/src/common.js
@@ -15,10 +15,13 @@ function setConfig(key, val) {
 }
 
 function loadScript(name, src) {
+    console.log('NoteFormat requesting', name, src);
+
     const isLoaded = getConfig(name+'.loaded', false);
 
     return new Promise((resolve, reject) => {
         if (isLoaded) {
+            console.log('NoteFormat script already loaded', name);
             if (typeof resolve === 'function') {
                 resolve();
                 return;
@@ -30,6 +33,7 @@ function loadScript(name, src) {
         script.src = src;
 
         script.onload = _ => {
+            console.log('NoteFormat loaded', name);
             window.SHOWDOWN_LOADED = true;
             setConfig(name+'.loaded', true);
             if (typeof resolve === 'function') {

--- a/resources/note-format/src/iframe.js
+++ b/resources/note-format/src/iframe.js
@@ -1,1 +1,10 @@
-function(note) { return "iframe"; }
+function (body) {
+    var sandbox = document.createElement('div');
+    sandbox.innerHTML = body;
+
+    Array.from(sandbox.querySelectorAll('iframe')).forEach(iframe => {
+        iframe.sandbox = 'allow-scripts allow-same-origin allow-forms';
+    });
+
+    return Promise.resolve(sandbox.innerHTML);
+}

--- a/resources/note-format/src/iframe.js
+++ b/resources/note-format/src/iframe.js
@@ -1,0 +1,1 @@
+function(note) { return "iframe"; }

--- a/resources/note-format/src/js-eval.js
+++ b/resources/note-format/src/js-eval.js
@@ -1,0 +1,22 @@
+function (body, note) {
+    const sandbox = document.createElement('div');
+    sandbox.innerHTML = body;
+
+    Array.from(sandbox.querySelectorAll('code.js')).forEach(elm => {
+        const escaper = document.createElement('textarea');
+        escaper.innerHTML = elm.innerHTML;
+
+        if (escaper.value.split('\n')[0].trim() !== '!eval') {
+            return;
+        }
+
+        const iframe = document.createElement('iframe');
+        iframe.sandbox = 'allow-scripts';
+        iframe.className = 'javascript';
+        iframe.srcdoc = '<script>' + escaper.value + '</script>';
+
+        elm.parentNode.replaceChild(iframe, elm);
+    });
+
+    return Promise.resolve(sandbox.innerHTML);
+}

--- a/resources/note-format/src/js-eval.js
+++ b/resources/note-format/src/js-eval.js
@@ -13,7 +13,9 @@ function (body, note) {
         const iframe = document.createElement('iframe');
         iframe.sandbox = 'allow-scripts';
         iframe.className = 'javascript';
-        iframe.srcdoc = '<script>' + escaper.value + '</script>';
+        iframe.srcdoc = '<script>'
+            + escaper.value.substring(6)
+            + '</script>';
 
         elm.parentNode.replaceChild(iframe, elm);
     });

--- a/resources/note-format/src/markdown.js
+++ b/resources/note-format/src/markdown.js
@@ -1,5 +1,6 @@
-function(note) {
-    note.html = 'this is markdown';
-
-    return note;
+function (body) {
+    return loadScript('showdown', 'js/showdown.min.js')
+    .then(() => {
+        return new showdown.Converter().makeHtml(body);
+    });
 }

--- a/resources/note-format/src/markdown.js
+++ b/resources/note-format/src/markdown.js
@@ -1,0 +1,1 @@
+function(note) { return "markdown"; }

--- a/resources/note-format/src/markdown.js
+++ b/resources/note-format/src/markdown.js
@@ -1,1 +1,5 @@
-function(note) { return "markdown"; }
+function(note) {
+    note.html = 'this is markdown';
+
+    return note;
+}

--- a/resources/note-format/src/mathjax.js
+++ b/resources/note-format/src/mathjax.js
@@ -1,1 +1,9 @@
-function(note) { return "mathjax"; }
+function (body) {
+    return loadScript('mathjax',
+        'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?' +
+        'config=TeX-MML-AM_CHTML')
+    .then(() => {
+        Vue.nextTick(_ => MathJax.Hub.Queue(["Typeset", MathJax.Hub]));
+        return body;
+    });
+}

--- a/resources/note-format/src/mathjax.js
+++ b/resources/note-format/src/mathjax.js
@@ -1,0 +1,1 @@
+function(note) { return "mathjax"; }

--- a/resources/note-format/state.json
+++ b/resources/note-format/state.json
@@ -1,0 +1,1 @@
+{"installed":["markdown"]}

--- a/resources/note-format/state.json
+++ b/resources/note-format/state.json
@@ -1,1 +1,1 @@
-{"installed":["markdown"]}
+{"installed":["markdown","asciinema","mathjax","iframe"]}

--- a/resources/note-format/state.json
+++ b/resources/note-format/state.json
@@ -1,1 +1,1 @@
-{"installed":["markdown","asciinema","mathjax","iframe"]}
+{"installed":["markdown","asciinema","mathjax","iframe","js-eval"]}

--- a/resources/note-format/state.json
+++ b/resources/note-format/state.json
@@ -1,1 +1,1 @@
-{"installed":["markdown","asciinema","mathjax","iframe","js-eval"]}
+{"installed":["markdown","iframe"]}

--- a/resources/views/index.html
+++ b/resources/views/index.html
@@ -255,6 +255,5 @@
     <script src="js/app.js"></script>
 
     <script src="js/asciinema-player.js"></script>
-    <script src="js/showdown.min.js"></script>
   </body>
 </html>

--- a/resources/views/index.html
+++ b/resources/views/index.html
@@ -9,7 +9,6 @@
     <link rel="stylesheet" href="css/asciinema-player.css">
     <link rel="stylesheet" href="css/style.css">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-MML-AM_CHTML'></script>
   </head>
 
   <body>
@@ -253,7 +252,5 @@
     <script src="js/vuex-logger.js"></script>
 
     <script src="js/app.js"></script>
-
-    <script src="js/asciinema-player.js"></script>
   </body>
 </html>

--- a/resources/vue/store/actions.js
+++ b/resources/vue/store/actions.js
@@ -30,10 +30,6 @@ SELECT_FIRST_NOTE: ({ state, commit, dispatch }) =>
         commit('DESELECT_NOTE'),
 
 
-RENDER_MATHJAX: ctx =>
-    Vue.nextTick(_ => MathJax.Hub.Queue(["Typeset", MathJax.Hub])),
-
-
 CREATE_NOTE: ({ state, commit, dispatch }) =>
     new Promise((resolve, reject) => {
         Vue.http.get(`./api/note/create`).then(request => {

--- a/resources/vue/store/index.js
+++ b/resources/vue/store/index.js
@@ -1,3 +1,5 @@
+// require ../../note-format/note-format.out.js
+//
 // require ./modules/selected-note.js
 // require ./modules/auto-save.js
 // require ./modules/modal.js

--- a/resources/vue/store/modules/selected-note.js
+++ b/resources/vue/store/modules/selected-note.js
@@ -34,14 +34,19 @@ const SelectedNote = {
         DESELECT_NOTE: state =>
             state.selectedNote = emptyNote,
 
-        RENDER_SELECTED_NOTE: state =>
-            state.selectedNote.html = new showdown.Converter()
-                .makeHtml(state.selectedNote.body)
-                .replace(/\$asciinema\([^\)\(]+\)/g, match => {
-                    var filename = match.substring(11).slice(0, -1);
-                    var path = ['./attachments', store.getters.getSelection.id, filename].join('/');
-                    return `<asciinema-player src="${path}"></asciinema-player>`;
-                }),
+        RENDER_SELECTED_NOTE: state => {
+            state.selectedNote.html = state.selectedNote.body;
+            state.selectedNote = formatters.reduce(function(note, formatter) {
+                return formatter(note);
+            }, state.selectedNote);
+            // state.selectedNote.html = new showdown.Converter()
+            //     .makeHtml(state.selectedNote.body)
+            //     .replace(/\$asciinema\([^\)\(]+\)/g, match => {
+            //         var filename = match.substring(11).slice(0, -1);
+            //         var path = ['./attachments', store.getters.getSelection.id, filename].join('/');
+            //         return `<asciinema-player src="${path}"></asciinema-player>`;
+            //     }),
+        },
 
         REMOVE_ATTACHMENT: (state, index) =>
             Vue.delete(this.selectedNote.attachments, index),

--- a/resources/vue/store/modules/selected-note.js
+++ b/resources/vue/store/modules/selected-note.js
@@ -35,13 +35,6 @@ const SelectedNote = {
             .then(html => {
                 Vue.set(state.selectedNote, 'html', html);
             });
-            // state.selectedNote.html = new showdown.Converter()
-            //     .makeHtml(state.selectedNote.body)
-            //     .replace(/\$asciinema\([^\)\(]+\)/g, match => {
-            //         var filename = match.substring(11).slice(0, -1);
-            //         var path = ['./attachments', store.getters.getSelection.id, filename].join('/');
-            //         return `<asciinema-player src="${path}"></asciinema-player>`;
-            //     }),
         },
 
         REMOVE_ATTACHMENT: (state, index) =>
@@ -126,7 +119,6 @@ const SelectedNote = {
             state.editing = false;
             state.versioning = false;
             commit('RENDER_SELECTED_NOTE');
-            dispatch('RENDER_MATHJAX');
         }
     }
 

--- a/resources/vue/store/modules/selected-note.js
+++ b/resources/vue/store/modules/selected-note.js
@@ -27,10 +27,14 @@ const SelectedNote = {
             state.selectedNote = makeEmptyNote(),
 
         RENDER_SELECTED_NOTE: state => {
-            state.selectedNote.html = state.selectedNote.body;
-            state.selectedNote = formatters.reduce(function(note, formatter) {
-                return formatter(note);
-            }, state.selectedNote);
+            // chain all the formatters so one feeds its body to the other
+            formatters.reduce((promise, formatter) =>
+                promise.then(body => formatter(body, state.selectedNote)),
+              Promise.resolve(state.selectedNote.body))
+            // then set the html property
+            .then(html => {
+                Vue.set(state.selectedNote, 'html', html);
+            });
             // state.selectedNote.html = new showdown.Converter()
             //     .makeHtml(state.selectedNote.body)
             //     .replace(/\$asciinema\([^\)\(]+\)/g, match => {

--- a/routes/console.php
+++ b/routes/console.php
@@ -4,16 +4,22 @@ use App\Console\Commands\NoteFormatter;
 
 
 
-Artisan::command('note-format:list', function () {
-    (new NoteFormatter())->list();
-})->describe('List all available formatters');
+Artisan::command('note-format:list {--all}', function ($all) {
+    (new NoteFormatter())->list($all);
+})->describe('List the installed formatters. Use --all for all');
 
 
-Artisan::command('note-format:install {plugins*}', function ($plugins) {
-    (new NoteFormatter())->install($plugins);
-})->describe('Install formatters');
+Artisan::command('note-format:install {--after=} {plugins*}',
+  function ($after, $plugins) {
+    return (new NoteFormatter())->install($after, $plugins);
+})->describe('Install formatters. Use --after= to indicate the index to add at');
 
 
-Artisan::command('note-format:remove {plugins*}', function ($plugins) {
-    (new NoteFormatter())->remove($plugins);
-})->describe('Remove formatters');
+Artisan::command('note-format:remove {plugin}', function ($plugin) {
+    return (new NoteFormatter())->remove($plugin);
+})->describe('Remove a single formatter (by index)');
+
+
+Artisan::command('note-format:compile', function () {
+    return (new NoteFormatter())->writeToOutput();
+})->describe('Generate the note-format.out.js file');

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,18 +1,19 @@
 <?php
 
-use Illuminate\Foundation\Inspiring;
+use App\Console\Commands\NoteFormatter;
 
-/*
-|--------------------------------------------------------------------------
-| Console Routes
-|--------------------------------------------------------------------------
-|
-| This file is where you may define all of your Closure based console
-| commands. Each Closure is bound to a command instance allowing a
-| simple approach to interacting with each command's IO methods.
-|
-*/
 
-Artisan::command('inspire', function () {
-    $this->comment(Inspiring::quote());
-})->describe('Display an inspiring quote');
+
+Artisan::command('note-format:list', function () {
+    (new NoteFormatter())->list();
+})->describe('List all available formatters');
+
+
+Artisan::command('note-format:install {plugins*}', function ($plugins) {
+    (new NoteFormatter())->install($plugins);
+})->describe('Install formatters');
+
+
+Artisan::command('note-format:remove {plugins*}', function ($plugins) {
+    (new NoteFormatter())->remove($plugins);
+})->describe('Remove formatters');


### PR DESCRIPTION
The point of this pull request is to make a system where everyone can control the rendered note. Presently I'm forcing asciinema and mathjax down users' throats, maybe someone doesn't want these. 

# Introducing the plugin system

A plugin is an anonymous function that takes the note of a body (string), and the note (object) and must return a promise of HTML (string). For example, here's the code for the markdown plugin:

```js
function (body) {
    return loadScript('showdown', 'js/showdown.min.js')
    .then(() => {
        return new showdown.Converter().makeHtml(body);
    });
}
```
It makes use of `loadScript(name, url)` common function which returns a promise which will get resolved right after loading the script at the provided URL.

A plugin should be registered in the repository located in `resources/note-format/repository.json` under the format:
```
{
    "name": "plugin name",
    "description": "a small description",
    "src": "src\/plugin-source.js",
}
```

Here's how to use the plugin manager:

```
> php artisan note-format:list
  1. markdown             - Renders the note in markdown
  2. mathjax              - Render LaTeX equations inside the note
  3. markdown             - Renders the note in markdown
```
will list the installed plugins in order of execution.

```
> php artisan note-format:list --all
5 available formatters

* markdown             - Renders the note in markdown
  iframe               - Play around with iframe attributes or block them
* mathjax              - Render LaTeX equations inside the note
  asciinema            - Use $asciinema(attachment_url) to include an asciinema cast
  js-eval              - Evaluate javascript code and display output in an <iframe>
```
will list all the plugins in the repository.

```
> php artisan note-format:install markdown asciinema --after=2
> php artisan note-format:list
  1. markdown             - Renders the note in markdown
  2. mathjax              - Render LaTeX equations inside the note
  3. markdown             - Renders the note in markdown
  4. asciinema            - Use $asciinema(attachment_url) to include an asciinema cast
  5. markdown             - Renders the note in markdown
```
will install the markdown and asciinema plugins after the second plugin.

```
> php artisan note-format:remove 3
> php artisan note-format:list
  1. markdown             - Renders the note in markdown
  2. mathjax              - Render LaTeX equations inside the note
  3. asciinema            - Use $asciinema(attachment_url) to include an asciinema cast
  4. markdown             - Renders the note in markdown
```
will remove the third plugin. Unfortunately it does not support multiple indeces, unlike the install rule.

```
php artisan note-format:compile
```
will produce the output javascript file.

## What it actually does

It generates a file in `resources/note-format/note-format.out.js` which is an array of the formatters to be applied in order.

**bundle-js should be executed after every compilation**

# Available formatters

## markdown
Will load Showdown and render the body to HTML.

## mathjax
Will load MathJax and will render equations.

## asciinema
Will replace all instances of `$asciinema(attachement-name.cast)` with an asciinema player

## iframe
Will set a sandbox around all iframes. The set value is "allow-scripts allow-same-origin allow-forms"

## js-eval
Evaluates all the javascript code that starts with `!eval` on its first line. The output is displayed inside a sandboxed iframe with only `allow-scripts`. For example if the note contains the code:

    ```js
    !eval
    for (var i=0; i < 10; i++) {
        document.write('hello world!<br>');
    }
    ```
Then this javascript is executed in an iframe that will show "hello world!" 10 times, each on a line.